### PR TITLE
Patch to fix issue #3

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -133,9 +133,7 @@ export default {
       this._clearWorker()
       this.state = STATE.SWITCH(this.state)
       this.timeRemaining = (STATE.GET_MODE(this.state) === 'WORK') ? this.workDuration : this.breakDuration
-      if (this.allowMelody) {
-        this._ringAlarm()
-      }
+      this._ringAlarm()
     },
     switchToSettingsView: function () {
       this.pauseTimer()

--- a/test/unit/specs/App.spec.js
+++ b/test/unit/specs/App.spec.js
@@ -545,41 +545,34 @@ describe('App', () => {
 
       CLOCK.restore()
     })
-    it('[triggerAlarm] rings the alarm if [allowMelody] is true', () => {
+    it('[triggerAlarm] executes [_ringAlarm] regardless of [allowMelody]/[allowVibration] settings', () => {
       // Restore the stubbed function so we can mock it
       // vm._ringAlarm.restore()
       // vm._stopAlarm.restore()
+      const settings = [
+        { allowMelody: false, allowVibration: false },
+        { allowMelody: true, allowVibration: true },
+        { allowMelody: true, allowVibration: false },
+        { allowMelody: true, allowVibration: true }
+      ]
 
-      // Setup mocks
-      var mock = sinon.mock(vm)
-      var ringAlarmExpectation = mock.expects('_ringAlarm')
-      var stopAlarmExpectation = mock.expects('_stopAlarm')
-      ringAlarmExpectation.once()
-      stopAlarmExpectation.never()
+      for (let i = 0; i < settings.length; i++) {
+        // Setup mocks
+        let mock = sinon.mock(vm)
+        let ringAlarmExpectation = mock.expects('_ringAlarm')
+        let stopAlarmExpectation = mock.expects('_stopAlarm')
+        ringAlarmExpectation.once()
+        stopAlarmExpectation.never()
 
-      // Verify it
-      vm.allowMelody = true
-      vm.triggerAlarm()
-      ringAlarmExpectation.verify()
-      stopAlarmExpectation.verify()
-    })
-    it('[triggerAlarm] rings the alarm if [allowMelody] is false', () => {
-      // Restore the stubbed function so we can mock it
-      // vm._ringAlarm.restore()
-      // vm._stopAlarm.restore()
-
-      // Setup mocks
-      var mock = sinon.mock(vm)
-      var ringAlarmExpectation = mock.expects('_ringAlarm')
-      var stopAlarmExpectation = mock.expects('_stopAlarm')
-      ringAlarmExpectation.never()
-      stopAlarmExpectation.never()
-
-      // Verify it
-      vm.allowMelody = false
-      vm.triggerAlarm()
-      ringAlarmExpectation.verify()
-      stopAlarmExpectation.verify()
+        // Verify it
+        vm.allowMelody = true
+        vm.allowMelody = settings[i].allowMelody
+        vm.allowVibration = settings[i].allowVibration
+        vm.triggerAlarm()
+        ringAlarmExpectation.verify()
+        stopAlarmExpectation.verify()
+        mock.restore()
+      }
     })
     it('[switchToSettingsView] pauses timer', () => {
       let spy = sinon.spy(vm, 'pauseTimer')


### PR DESCRIPTION
#### Short description of what this resolves:
Alarm will now trigger vibration based solely on the [*Vibrate on Alarm*] setting regardless of whether [*Play Alarm Melody*] setting is enabled/disabled.

#### Changes proposed in this pull request:
- [test/unit/specs/App.spec.js] Modified unit test to catch the bug filed in issue #3. 
- [src/App.vue] Removed branch statement for checking **this.allowMelody** in the **triggerAlarm()** function.

**Fixes**: #3

Before submitting your PR, please review the following checklist:

- [x] **DO** add a unit test if your PR resolves an issue.
- [x] **DO** make sure unit tests pass.
- [x] **DO** make sure not to introduce any compiler warnings.
- [x] **AVOID** breaking the continuous integration build.
